### PR TITLE
Rename properties xxxClassName to xxxClasses

### DIFF
--- a/src/block/block-prop-types.js
+++ b/src/block/block-prop-types.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
 
 export const blockPropTypes = {
-    blockClassName: PropTypes.string
+    blockClasses: PropTypes.string
 };

--- a/src/block/block.jsx
+++ b/src/block/block.jsx
@@ -31,12 +31,12 @@ export function block(blockName, mapPropsToModifiers = noop) {
                 const {className} = this.props;
                 const modifiers = mapPropsToModifiers(this.props);
                 const blockNameFactory = createBlockNameFactory(blockName);
-                const blockClassName = cx(
+                const blockClasses = cx(
                     blockNameFactory(),
                     modifiers && blockNameFactory(modifiers),
                     className
                 );
-                return <WrappedComponent {...this.props} blockClassName={blockClassName} />;
+                return <WrappedComponent {...this.props} blockClasses={blockClasses} />;
             }
         };
     };

--- a/src/block/block.spec.jsx
+++ b/src/block/block.spec.jsx
@@ -20,34 +20,34 @@ describe('BEM block decorator', () => {
         expect(WrappedFoo.displayName).toEqual('block(foo)');
     });
 
-    it('should inject [blockClassName] property', () => {
+    it('should inject [blockClasses] property', () => {
         const WrappedFoo = block('foo')(Foo);
         renderer.render(<WrappedFoo />);
         const wrappedFoo = renderer.getRenderOutput();
-        expect(isString(wrappedFoo.props.blockClassName)).toBeTruthy();
-        expect(wrappedFoo.props.blockClassName).toEqual('foo');
+        expect(isString(wrappedFoo.props.blockClasses)).toBeTruthy();
+        expect(wrappedFoo.props.blockClasses).toEqual('foo');
     });
 
-    it('should mixin provided [className] property into [blockClassName] property', () => {
+    it('should mixin provided [className] property into [blockClasses] property', () => {
         const WrappedFoo = block('foo')(Foo);
         renderer.render(<WrappedFoo className="quux" />);
         const wrappedFoo = renderer.getRenderOutput();
-        expect(isString(wrappedFoo.props.blockClassName)).toBeTruthy();
-        const fooClasses = wrappedFoo.props.blockClassName.split(' ');
+        expect(isString(wrappedFoo.props.blockClasses)).toBeTruthy();
+        const fooClasses = wrappedFoo.props.blockClasses.split(' ');
         expect(fooClasses).toHaveLength(2);
         expect(fooClasses).toContain('foo');
         expect(fooClasses).toContain('quux');
     });
 
-    it('should map properties to modifiers and mixin corresponding classes to [blockClassName]', () => {
+    it('should map properties to modifiers and mixin corresponding classes to [blockClasses]', () => {
         const WrappedFoo = block(
             'foo',
             ({bar}) => `bar-${bar}`
         )(Foo);
         renderer.render(<WrappedFoo bar="quux" />);
         const wrappedFoo = renderer.getRenderOutput();
-        expect(isString(wrappedFoo.props.blockClassName)).toBeTruthy();
-        const fooClasses = wrappedFoo.props.blockClassName.split(' ');
+        expect(isString(wrappedFoo.props.blockClasses)).toBeTruthy();
+        const fooClasses = wrappedFoo.props.blockClasses.split(' ');
         expect(fooClasses).toHaveLength(2);
         expect(fooClasses).toContain('foo');
         expect(fooClasses).toContain(`foo${MODIFIER_SEPARATOR}bar-quux`);
@@ -63,8 +63,8 @@ describe('BEM block decorator', () => {
         )(Foo);
         renderer.render(<WrappedFoo bar={false} baz="quxx" />);
         const wrappedFoo = renderer.getRenderOutput();
-        expect(isString(wrappedFoo.props.blockClassName)).toBeTruthy();
-        const fooClasses = wrappedFoo.props.blockClassName.split(' ');
+        expect(isString(wrappedFoo.props.blockClasses)).toBeTruthy();
+        const fooClasses = wrappedFoo.props.blockClasses.split(' ');
         expect(fooClasses).toHaveLength(3);
         expect(fooClasses).toContain('foo');
         expect(fooClasses).toContain(`foo${MODIFIER_SEPARATOR}not-bar`);
@@ -82,8 +82,8 @@ describe('BEM block decorator', () => {
         )(Foo);
         renderer.render(<WrappedFoo bar="quux" />);
         const wrappedFoo = renderer.getRenderOutput();
-        expect(isString(wrappedFoo.props.blockClassName)).toBeTruthy();
-        const fooClasses = wrappedFoo.props.blockClassName.split(' ');
+        expect(isString(wrappedFoo.props.blockClasses)).toBeTruthy();
+        const fooClasses = wrappedFoo.props.blockClasses.split(' ');
         expect(fooClasses).toHaveLength(2);
         expect(fooClasses).toContain('foo#123');
         expect(fooClasses).toContain('quux#456');

--- a/src/element/element-prop-types.js
+++ b/src/element/element-prop-types.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
 
 export const elementPropTypes = {
-    elementClassName: PropTypes.string
+    elementClasses: PropTypes.string
 };

--- a/src/element/element.jsx
+++ b/src/element/element.jsx
@@ -18,12 +18,12 @@ export function element(elementName, mapPropsToModifiers = noop) {
             const {className} = props;
             const modifiers = mapPropsToModifiers(props, normalizeBlockModifiers(blockModifiers));
             const elementNameFactory = createElementNameFactory(blockName, elementName);
-            const elementClassName = cx(
+            const elementClasses = cx(
                 elementNameFactory(),
                 modifiers && elementNameFactory(modifiers),
                 className
             );
-            return <WrappedComponent {...props} elementClassName={elementClassName} />;
+            return <WrappedComponent {...props} elementClasses={elementClasses} />;
         }
         Wrapper.displayName = `element(${elementName})`;
         Wrapper.contextTypes = blockContextTypes;

--- a/src/element/element.spec.jsx
+++ b/src/element/element.spec.jsx
@@ -20,34 +20,34 @@ describe('BEM element decorator', () => {
         expect(WrappedFooBar.displayName).toEqual('element(bar)');
     });
 
-    it('should inject [elementClassName] property', () => {
+    it('should inject [elementClasses] property', () => {
         const WrappedFooBar = element('bar')(FooBar);
         renderer.render(<WrappedFooBar />, {blockName: 'foo'});
         const wrappedFooBar = renderer.getRenderOutput();
-        expect(isString(wrappedFooBar.props.elementClassName)).toBeTruthy();
-        expect(wrappedFooBar.props.elementClassName).toEqual(`foo${ELEMENT_SEPARATOR}bar`);
+        expect(isString(wrappedFooBar.props.elementClasses)).toBeTruthy();
+        expect(wrappedFooBar.props.elementClasses).toEqual(`foo${ELEMENT_SEPARATOR}bar`);
     });
 
-    it('should mixin provided [className] property into [elementClassName] property', () => {
+    it('should mixin provided [className] property into [elementClasses] property', () => {
         const WrappedFooBar = element('bar')(FooBar);
         renderer.render(<WrappedFooBar className="quux" />, {blockName: 'foo'});
         const wrappedFooBar = renderer.getRenderOutput();
-        expect(isString(wrappedFooBar.props.elementClassName)).toBeTruthy();
-        const fooBarClasses = wrappedFooBar.props.elementClassName.split(' ');
+        expect(isString(wrappedFooBar.props.elementClasses)).toBeTruthy();
+        const fooBarClasses = wrappedFooBar.props.elementClasses.split(' ');
         expect(fooBarClasses).toHaveLength(2);
         expect(fooBarClasses).toContain(`foo${ELEMENT_SEPARATOR}bar`);
         expect(fooBarClasses).toContain('quux');
     });
 
-    it('should map properties to modifiers and mixin corresponding classes to [elementClassName]', () => {
+    it('should map properties to modifiers and mixin corresponding classes to [elementClasses]', () => {
         const WrappedFooBar = element(
             'bar',
             ({baz}) => `baz-${baz}`
         )(FooBar);
         renderer.render(<WrappedFooBar baz="quux" />, {blockName: 'foo'});
         const wrappedFooBar = renderer.getRenderOutput();
-        expect(isString(wrappedFooBar.props.elementClassName)).toBeTruthy();
-        const fooBarClasses = wrappedFooBar.props.elementClassName.split(' ');
+        expect(isString(wrappedFooBar.props.elementClasses)).toBeTruthy();
+        const fooBarClasses = wrappedFooBar.props.elementClasses.split(' ');
         expect(fooBarClasses).toHaveLength(2);
         expect(fooBarClasses).toContain(`foo${ELEMENT_SEPARATOR}bar`);
         expect(fooBarClasses).toContain(`foo${ELEMENT_SEPARATOR}bar${MODIFIER_SEPARATOR}baz-quux`);
@@ -60,8 +60,8 @@ describe('BEM element decorator', () => {
         )(FooBar);
         renderer.render(<WrappedFooBar baz={false} />, {blockName: 'foo'});
         const wrappedFooBar = renderer.getRenderOutput();
-        expect(isString(wrappedFooBar.props.elementClassName)).toBeTruthy();
-        const fooBarClasses = wrappedFooBar.props.elementClassName.split(' ');
+        expect(isString(wrappedFooBar.props.elementClasses)).toBeTruthy();
+        const fooBarClasses = wrappedFooBar.props.elementClasses.split(' ');
         expect(fooBarClasses).toHaveLength(2);
         expect(fooBarClasses).toContain(`foo${ELEMENT_SEPARATOR}bar`);
         expect(fooBarClasses).toContain(`foo${ELEMENT_SEPARATOR}bar${MODIFIER_SEPARATOR}not-baz`);
@@ -78,8 +78,8 @@ describe('BEM element decorator', () => {
         )(FooBar);
         renderer.render(<WrappedFooBar baz="quux" />, {blockName: 'foo'});
         const wrappedFooBar = renderer.getRenderOutput();
-        expect(isString(wrappedFooBar.props.elementClassName)).toBeTruthy();
-        const fooBarClasses = wrappedFooBar.props.elementClassName.split(' ');
+        expect(isString(wrappedFooBar.props.elementClasses)).toBeTruthy();
+        const fooBarClasses = wrappedFooBar.props.elementClasses.split(' ');
         expect(fooBarClasses).toHaveLength(2);
         expect(fooBarClasses).toContain('foo#123');
         expect(fooBarClasses).toContain('quux#456');


### PR DESCRIPTION
Actually, property xxxClassName holds a string with space separated class names.