### PR TITLE
Function which is created by createModifiersMapper handles incorrect inputs

### DIFF
--- a/src/assertion.js
+++ b/src/assertion.js
@@ -1,0 +1,14 @@
+import isString from 'lodash/isString';
+import stubFalse from 'lodash/stubFalse';
+import {Config} from './config';
+
+export function assertion(validator, message) {
+    if (isString(validator)) {
+        return assertion(stubFalse, validator);
+    }
+    return (...args) => {
+        if (Config.ASSERTION_ENABLED && !validator(...args)) {
+            throw new Error(`[BEM] ${message}: ${JSON.stringify(args)}`);
+        }
+    };
+}

--- a/src/bem-naming-factory/bem-naming-factory.js
+++ b/src/bem-naming-factory/bem-naming-factory.js
@@ -1,13 +1,6 @@
-import isString from 'lodash/isString';
-import isPlainObject from 'lodash/isPlainObject';
-import isArray from 'lodash/isArray';
-import mapKeys from 'lodash/mapKeys';
-import compact from 'lodash/compact';
-import kebabCase from 'lodash/kebabCase';
 import {Config} from '../config';
 import {assertNamePart} from '../bem-naming-validators';
-
-const {ELEMENT_SEPARATOR, MODIFIER_SEPARATOR} = Config;
+import {createModifiersMapper} from './modifiers-mapper-creator';
 
 export function createBlockNameFactory(block) {
     assertNamePart(block);
@@ -17,20 +10,5 @@ export function createBlockNameFactory(block) {
 export function createElementNameFactory(block, element) {
     assertNamePart(block);
     assertNamePart(element);
-    return createModifiersMapper(`${block}${ELEMENT_SEPARATOR}${element}`);
-}
-
-function createModifiersMapper(name) {
-    return function mapModifier(modifier) {
-        if (modifier && isString(modifier)) {
-            const adjustedModifier = kebabCase(modifier);
-            assertNamePart(adjustedModifier);
-            return `${name}${MODIFIER_SEPARATOR}${adjustedModifier}`;
-        } else if (isPlainObject(modifier)) {
-            return mapKeys(modifier, (value, key) => mapModifier(key));
-        } else if (isArray(modifier)) {
-            return compact(modifier).map(mapModifier);
-        }
-        return name;
-    };
+    return createModifiersMapper(`${block}${Config.ELEMENT_SEPARATOR}${element}`);
 }

--- a/src/bem-naming-factory/modifiers-mapper-creator.js
+++ b/src/bem-naming-factory/modifiers-mapper-creator.js
@@ -1,0 +1,29 @@
+import isString from 'lodash/isString';
+import isPlainObject from 'lodash/isPlainObject';
+import isUndefined from 'lodash/isUndefined';
+import isArray from 'lodash/isArray';
+import mapKeys from 'lodash/mapKeys';
+import kebabCase from 'lodash/kebabCase';
+import compact from 'lodash/compact';
+import {assertNamePart} from '../bem-naming-validators';
+import {Config} from '../config';
+import {assertion} from '../assertion';
+
+const typeAssertion = assertion('Modifier has inappropriate type');
+
+export function createModifiersMapper(name) {
+    return function mapModifier(modifier) {
+        if (isUndefined(modifier) || modifier === '') {
+            return name;
+        } else if (isString(modifier)) {
+            const adjustedModifier = kebabCase(modifier);
+            assertNamePart(adjustedModifier);
+            return `${name}${Config.MODIFIER_SEPARATOR}${adjustedModifier}`;
+        } else if (isPlainObject(modifier)) {
+            return mapKeys(modifier, (value, key) => mapModifier(key));
+        } else if (isArray(modifier)) {
+            return compact(modifier).map(mapModifier);
+        }
+        typeAssertion({name, modifier});
+    };
+}

--- a/src/bem-naming-factory/modifires-mapper-creator.spec.js
+++ b/src/bem-naming-factory/modifires-mapper-creator.spec.js
@@ -1,0 +1,54 @@
+import {createModifiersMapper} from './modifiers-mapper-creator';
+import {Config} from '../config';
+
+Config.ASSERTION_ENABLED = true;
+
+const {MODIFIER_SEPARATOR} = Config;
+const INVALID_STRING_MODIFIERS = [' ', '*--*', 'кирилица', '4-start-with-digit'];
+const MODIFIERS_WITH_INAPPROPRIATE_TYPE = [22, true, null, /.*/, new Date(), NaN, () => {}, Symbol()];
+
+describe('function which is created by createModifiersMapper(_name_) ', () => {
+    let modifiersMapper;
+    beforeEach(() => {
+        modifiersMapper = createModifiersMapper('foo');
+    });
+
+    it('should map all array items and object keys', () => {
+        expect(modifiersMapper([
+            'baz',
+            {bar: true},
+            ['arr' ,
+                ['sub-arr']
+            ]
+        ])).toEqual([
+            `foo${MODIFIER_SEPARATOR}baz`,
+            {[`foo${MODIFIER_SEPARATOR}bar`]: true},
+            [`foo${MODIFIER_SEPARATOR}arr`,
+                [`foo${MODIFIER_SEPARATOR}sub-arr`]
+            ]
+        ]);
+    });
+
+
+    it('should ignore falsey items in the array of modifiers', () => {
+        expect(modifiersMapper([undefined, 'baz', null, false, 0, '']))
+            .toEqual([`foo${MODIFIER_SEPARATOR}baz`]);
+    });
+
+    it('should return _name_ if modifier is undefined', () => {
+        expect(modifiersMapper()).toEqual(`foo`);
+    });
+
+    it('should return _name_ if modifier is an empty string', () => {
+        expect(modifiersMapper('')).toEqual(`foo`);
+    });
+
+    it('should fail in case of the modifier is an invalid string ', () => {
+        INVALID_STRING_MODIFIERS.forEach((modifierStr) => expect(() => modifiersMapper(modifierStr)).toThrow());
+    });
+
+    it('should fail in case of the modifier has inappropriate type', () => {
+        MODIFIERS_WITH_INAPPROPRIATE_TYPE.forEach((modifier) => expect(() => modifiersMapper(modifier)).toThrow());
+    });
+});
+

--- a/src/bem-naming-validators/bem-naming-validators.js
+++ b/src/bem-naming-validators/bem-naming-validators.js
@@ -1,7 +1,8 @@
-import isString from 'lodash/isString';
 import camelCase from 'lodash/camelCase';
 import upperFirst from 'lodash/upperFirst';
-import {Config} from '../config';
+import isString from 'lodash/isString';
+import { assertion } from '../assertion';
+
 
 export function isValidNamePart(name) {
     return isString(name) && name.split('-')
@@ -21,11 +22,3 @@ export const assertComponentName = assertion(
     isValidComponentName,
     'Invalid component name'
 );
-
-function assertion(validator, message) {
-    return (...args) => {
-        if (Config.ASSERTION_ENABLED && !validator(...args)) {
-            throw new Error(`[BEM] ${message}: ${JSON.stringify(args)}`);
-        }
-    };
-}


### PR DESCRIPTION
Move createModifiersMapper to a separate file.
Add tests.