### PR TITLE
Block puts style map to context. Element maps output classes names according this map.

### DIFF
--- a/src/block/block-context-types.js
+++ b/src/block/block-context-types.js
@@ -2,5 +2,6 @@ import PropTypes from 'prop-types';
 
 export const blockContextTypes = {
     blockName: PropTypes.string,
-    blockModifiers: PropTypes.string
+    blockModifiers: PropTypes.string,
+    blockStyles: PropTypes.object
 };

--- a/src/block/block.jsx
+++ b/src/block/block.jsx
@@ -23,7 +23,8 @@ export function block(blockName, mapPropsToModifiers = noop) {
                 const modifiers = mapPropsToModifiers(this.props);
                 return {
                     blockName,
-                    blockModifiers: classNames(modifiers)
+                    blockModifiers: classNames(modifiers),
+                    blockStyles: WrappedComponent.styles
                 };
             }
 

--- a/src/element/element.jsx
+++ b/src/element/element.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import noop from 'lodash/noop';
 import isFunction from 'lodash/isFunction';
 import zipObject from 'lodash/zipObject';
+import assign from 'lodash/assign';
 import classNames from 'classnames/bind';
 import {assertNamePart} from '../bem-naming-validators';
 import {createElementNameFactory} from '../bem-naming-factory';
@@ -13,8 +14,8 @@ export function element(elementName, mapPropsToModifiers = noop) {
         throw new TypeError('[mapPropsToModifiers] should be a function');
     }
     return (WrappedComponent) => {
-        const cx = classNames.bind(WrappedComponent.styles || {});
-        function Wrapper(props, {blockName, blockModifiers} = {}) {
+        function Wrapper(props, {blockName, blockModifiers, blockStyles} = {}) {
+            const cx = classNames.bind(assign({}, blockStyles, WrappedComponent.styles));
             const {className} = props;
             const modifiers = mapPropsToModifiers(props, normalizeBlockModifiers(blockModifiers));
             const elementNameFactory = createElementNameFactory(blockName, elementName);

--- a/src/element/element.spec.jsx
+++ b/src/element/element.spec.jsx
@@ -58,31 +58,13 @@ describe('BEM element decorator', () => {
             'bar',
             ({baz}) => ({notBaz: !baz})
         )(FooBar);
-        renderer.render(<WrappedFooBar baz={false} />, {blockName: 'foo'});
+        renderer.render(<WrappedFooBar baz={false}/>, {blockName: 'foo'});
         const wrappedFooBar = renderer.getRenderOutput();
         expect(isString(wrappedFooBar.props.elementClassName)).toBeTruthy();
         const fooBarClasses = wrappedFooBar.props.elementClassName.split(' ');
         expect(fooBarClasses).toHaveLength(2);
         expect(fooBarClasses).toContain(`foo${ELEMENT_SEPARATOR}bar`);
         expect(fooBarClasses).toContain(`foo${ELEMENT_SEPARATOR}bar${MODIFIER_SEPARATOR}not-baz`);
-    });
-
-    it('should support modular CSS (styles map should be defined as static field [styles])', () => {
-        FooBar.styles = {
-            [`foo${ELEMENT_SEPARATOR}bar`]: 'foo#123',
-            [`foo${ELEMENT_SEPARATOR}bar${MODIFIER_SEPARATOR}baz-quux`]: 'quux#456'
-        };
-        const WrappedFooBar = element(
-            'bar',
-            ({baz}) => `baz-${baz}`
-        )(FooBar);
-        renderer.render(<WrappedFooBar baz="quux" />, {blockName: 'foo'});
-        const wrappedFooBar = renderer.getRenderOutput();
-        expect(isString(wrappedFooBar.props.elementClassName)).toBeTruthy();
-        const fooBarClasses = wrappedFooBar.props.elementClassName.split(' ');
-        expect(fooBarClasses).toHaveLength(2);
-        expect(fooBarClasses).toContain('foo#123');
-        expect(fooBarClasses).toContain('quux#456');
     });
 
     it('should pass block modifiers to [mapPropsToModifiers] function as second argument', () => {
@@ -114,5 +96,67 @@ describe('BEM element decorator', () => {
 
     it('should fail in case of invalid element name (not kebab-case)', () => {
         expect(() => element('BAR')).toThrow(/^\[BEM\].+/);
+    });
+
+    describe('which wraps a component with modular css', () => {
+        function checkClasses(renderer) {
+            const wrappedFooBar = renderer.getRenderOutput();
+            expect(isString(wrappedFooBar.props.elementClassName)).toBeTruthy();
+            const fooBarClasses = wrappedFooBar.props.elementClassName.split(' ');
+            expect(fooBarClasses).toHaveLength(2);
+            expect(fooBarClasses).toContain('foo#123');
+            expect(fooBarClasses).toContain('quux#456');
+        }
+
+        it('should take a class mapping from the static field [styles]', () => {
+            FooBar.styles = {
+                [`foo${ELEMENT_SEPARATOR}bar`]: 'foo#123',
+                [`foo${ELEMENT_SEPARATOR}bar${MODIFIER_SEPARATOR}baz-quux`]: 'quux#456'
+            };
+            const WrappedFooBar = element(
+                'bar',
+                ({baz}) => `baz-${baz}`
+            )(FooBar);
+            renderer.render(<WrappedFooBar baz="quux"/>, {blockName: 'foo'});
+            checkClasses(renderer);
+        });
+
+        it('should take a class mapping from the context property [blockStyles]', () => {
+            const WrappedFooBar = element(
+                'bar',
+                ({baz}) => `baz-${baz}`
+            )(FooBar);
+            renderer.render(
+                <WrappedFooBar baz="quux" />,
+                {
+                    blockName: 'foo',
+                    blockStyles: {
+                        [`foo${ELEMENT_SEPARATOR}bar`]: 'foo#123',
+                        [`foo${ELEMENT_SEPARATOR}bar${MODIFIER_SEPARATOR}baz-quux`]: 'quux#456'
+                    }
+                }
+            );
+            checkClasses(renderer);
+        });
+
+        it('should take a class mapping from the context property and from the static field', () => {
+            FooBar.styles = {
+                [`foo${ELEMENT_SEPARATOR}bar`]: 'foo#123'
+            };
+            const WrappedFooBar = element(
+                'bar',
+                ({baz}) => `baz-${baz}`
+            )(FooBar);
+            renderer.render(
+                <WrappedFooBar baz="quux" />,
+                {
+                    blockName: 'foo',
+                    blockStyles: {
+                        [`foo${ELEMENT_SEPARATOR}bar${MODIFIER_SEPARATOR}baz-quux`]: 'quux#456'
+                    }
+                }
+            );
+            checkClasses(renderer);
+        });
     });
 });


### PR DESCRIPTION
It is very useful for small elements, which do not have separate styles.